### PR TITLE
Add Pre-Mockups Run Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test-ci": "jest --config test/unit/jest.conf.js --testResultsProcessor=./node_modules/jest-junit-reporter",
     "lint": "eslint --ext .js,.vue src test/unit",
     "build": "node build/build.js",
-    "mockups": "webpack-dev-server --inline --progress --config build/webpack.mockups.conf.js"
+    "mockups": "webpack-dev-server --inline --progress --config build/webpack.mockups.conf.js",
+    "premockups": "npm install"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
Add a `premockups` script to `package.json` so you don't have to remember to run `npm install` first.