### PR TITLE
HBCA-5 Autocomplete Styling

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -34,6 +34,8 @@ body {
 .grid-content {
   padding-left: 0;
   padding-right: 0;
+  /* prevents autocomplete being clipped */
+  overflow-y: visible;
 }
 
 h1 {
@@ -944,6 +946,7 @@ th {
 
 .saved-terms {
   margin-top:30px;
+  min-height:40px;
 }
 
 .question-row {

--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -159,7 +159,7 @@ export default {
 
 <style lang="css">
 .autocomplete {
-  margin-top: 50px;
+  position: relative;
 }
 
 .autocomplete input {
@@ -167,12 +167,30 @@ export default {
 }
 
 .autocomplete .dropdown-pane {
-  position: inherit;
-  width: 100%;
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid #7e7e7e;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 99;
+  visibility: hidden;
+}
+
+.autocomplete .dropdown-pane.is-open {
+  visibility: visible;
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .autocomplete .dropdown-pane ul li {
   list-style-type: none;
+}
+
+.autocomplete .dropdown-pane li:before {
+  content: none;
 }
 
 .highlighted {

--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -169,7 +169,7 @@ export default {
 .autocomplete .dropdown-pane {
   padding: 1rem;
   background: #fff;
-  border: 1px solid #7e7e7e;
+  border: 1px solid #ccc;
   position: absolute;
   top: 100%;
   left: 0;


### PR DESCRIPTION
Style the autocomplete input better for demo. This was broken a bit by switching to [Foundation for Apps](https://foundation.zurb.com/apps.html) a couple of days ago. New styles are borrowed from the [Foundation for Sites dropdown panel](https://foundation.zurb.com/sites/docs/dropdown.html) and a bit of experimentation.

I consider this work semi-temporary. I just don't want things to look awful for review.

## Before

<img width="601" alt="autocomplete-before" src="https://user-images.githubusercontent.com/2746306/39788148-e3e38ec6-52dd-11e8-8474-6e197f2454ec.png">

## After

<img width="572" alt="autocomplete-after" src="https://user-images.githubusercontent.com/2746306/39788287-9fe4f4b6-52de-11e8-8e1a-7f86d4631db9.png">

