### PR TITLE
Add Context to Build Config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -54,7 +54,7 @@ module.exports = {
     // Paths
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: '/phenotypr',
 
     /**
      * Source Maps


### PR DESCRIPTION
Add the context path to build config so output works when deployed to the server.