### PR TITLE
HBCA-3 fixed empty suggestions on enter

### DIFF
--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -58,7 +58,9 @@ export default {
      * @param {Number} index - the index in the `suggestions` array of the item selected.
      */
     selectItem(index) {
-      this.$emit('itemSelected', this.suggestions[index]);
+      if (typeof this.suggestions[index] !== 'undefined') {
+        this.$emit('itemSelected', this.suggestions[index]);
+      }
     },
 
     /**

--- a/test/unit/specs/components/SearchInput.spec.js
+++ b/test/unit/specs/components/SearchInput.spec.js
@@ -152,6 +152,15 @@ describe('SearchInput.vue', () => {
     expect(state.queryText).toEqual('');
   });
 
+  test('hitting enter without a selection does not emit an item', () => {
+    const wrapper = shallow(SearchInput);
+
+    const input = wrapper.find('input');
+    input.trigger('keydown.enter');
+
+    expect(wrapper.emitted().itemSelected).toBe(undefined);
+  });
+
   test('clicking a suggestion selects it', () => {
     const wrapper = shallow(SearchInput, {
       data: {


### PR DESCRIPTION
A blank search triggers a JS exception. This ensures that a selected item is not
being emitted.