### PR TITLE
Search Improvements

### DIFF
--- a/src/components/SearchPage.vue
+++ b/src/components/SearchPage.vue
@@ -37,7 +37,7 @@
       <!-- forms -->
       <div class="grid-x grid-margin-x button-container">
         <div class="cell large-8 text-right">
-          <input type="button" value="Done adding symptoms" class="button rounded" @click="goToResults">
+          <input type="button" value="Done adding symptoms" class="button rounded" :disabled="selectionIsEmpty" @click="goToResults">
         </div>
       </div>
     </form>
@@ -70,7 +70,9 @@ export default {
   },
 
   computed: mapState({
-    selections: 'selectedTerms'
+    selections: 'selectedTerms',
+
+    selectionIsEmpty: state => state.selectedTerms && state.selectedTerms.length < 1
   })
 };
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,12 +9,15 @@ export default {
   state: initialState,
   mutations: {
     /**
-     * Add an HPO term to the selected terms.
+     * Add an HPO term to the selected terms if it is not already present.
      * @param {Object} state - the current state.
      * @param {Object} term - an HPO term from Solr.
      */
     addTerm(state, term) {
-      state.selectedTerms.push(term);
+      const found = state.selectedTerms.find(current => current.id === term.id);
+      if (!found) {
+        state.selectedTerms.push(term);
+      }
     },
 
     /**

--- a/test/unit/specs/components/SearchPage.spec.js
+++ b/test/unit/specs/components/SearchPage.spec.js
@@ -52,6 +52,15 @@ describe('SearchPage.vue', () => {
     expect(mutations.removeTermAtIndex).toHaveBeenCalledWith(state, 1);
   });
 
+  test('the button is disabled when no terms are selected', () => {
+    const wrapper = shallow(SearchPage, { store, localVue });
+    const submitButton = wrapper.find('input[type=button]');
+    expect(submitButton.attributes().disabled).toBeUndefined();
+
+    state.selectedTerms = [];
+    expect(submitButton.attributes().disabled).toBeDefined();
+  });
+
   test('clicking the button transitions to the results route', () => {
     const mocks = {
       $router: {

--- a/test/unit/specs/store/store.spec.js
+++ b/test/unit/specs/store/store.spec.js
@@ -30,6 +30,16 @@ describe('vuex store', () => {
       expect(mockState.selectedTerms[1]).toEqual(term);
     });
 
+    test('addTerm prevents adding duplicate terms', () => {
+      const term = exampleResponses[1];
+      const mockState = {
+        selectedTerms: [term]
+      };
+
+      mutations.addTerm(mockState, term);
+      expect(mockState.selectedTerms.length).toEqual(1);
+    });
+
     test('removeTermAtIndex removes the term from the array', () => {
       const expectedItem = exampleResponses[2];
       const mockState = {


### PR DESCRIPTION
Minor fixes to the search route:

* HBCA-24: Prevent selecting the same term multiple times
* HBCA-25: Prevent transitioning to the term export route without selecting any terms