### PR TITLE
Bold Search Highlighting

### DIFF
--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -237,7 +237,7 @@ export default {
 
 .autocomplete .search-results.is-open {
   visibility: visible;
-  max-height: 460px;
+  max-height: 470px;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -257,5 +257,10 @@ export default {
 
 .highlighted {
   background-color: #f8f8f8;
+}
+
+em.hilite {
+  /* font-style: normal; */
+  font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Bold highlighted words in search output to make highlighting more prominent. Resolves #31.

Before:

![search-highlighting-before](https://user-images.githubusercontent.com/2746306/41247804-072f0964-6d64-11e8-876e-6785072b0079.png)

After:

![search-highlighting-after](https://user-images.githubusercontent.com/2746306/41247811-0b68a602-6d64-11e8-8edd-10b9351b1859.png)
