### PR TITLE
Quality Score Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14189,6 +14189,11 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.1.tgz",
       "integrity": "sha512-vLLoY452L+JBpALMP5UHum9+7nzR9PeIBCghU9ZtJ1eWm6ieUI8Zb/DI3MYxH32bxkjzYV1LRjNv4qr8d+uX/w=="
     },
+    "vue-star-rating": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vue-star-rating/-/vue-star-rating-1.6.0.tgz",
+      "integrity": "sha1-hYbZ0QBVX9Nn3x47dpZp6DcIkgk="
+    },
     "vue-style-loader": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "striptags": "^2.2.1",
     "vue": "^2.5.2",
     "vue-router": "^3.0.1",
+    "vue-star-rating": "^1.6.0",
     "vuex": "^3.0.1"
   },
   "devDependencies": {

--- a/src/components/AnnotationSufficiency.vue
+++ b/src/components/AnnotationSufficiency.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="cell medium-8 large-6">
+    <p>Profile sufficiency: <span class="score-category">{{ category }}</span>
+      <star-rating
+        v-model="scaledScore"
+        active-color="#5aa4d2"
+        :increment="0.5"
+        :read-only="true"
+        :show-rating="false"
+        :inline="true"
+        :star-size="16"
+        :rounded-corners="true"/>
+    </p>
+
+    <p class="score-help">To help your doctor diagnose you most accurately:
+      <ul>
+        <li>Enter as many symptoms as you can</li>
+        <li>Be as specific as you can be</li>
+        <li>Try to cover as many body symptoms as apply to you (e.g. symptoms in the head
+          and neck, face, eyes, ears, muscles, joints, bones, internal organs, etc.)</li>
+        <li>Don't forget conditions that are not local to a specific body part (e.g. stroke,
+          fever, numbness, sensitivity to pain, etc.)</li>
+        <li>Don't forget conditions like sleep disturbances, memory loss, cognitive disability,
+          developmental delay</li>
+      </ul>
+    </p>
+  </div>
+</template>
+
+<script>
+import StarRating from 'vue-star-rating';
+
+/**
+ * Displays information about the diagnostic usefulness of the selected terms, based on
+ * the score obtained from the Monarch Initiative API.
+ */
+export default {
+  name: 'AnnotationSufficiency',
+
+  components: {
+    StarRating
+  },
+
+  props: {
+    score: Number
+  },
+
+  data() {
+    return {
+      categoryLabels: [
+        'Very Poor',
+        'Poor',
+        'Fair',
+        'Good',
+        'Very Good'
+      ]
+    };
+  },
+
+  methods: {
+    /**
+     * Coerces the input value to a valid index into the `categoryLabels` array.
+     * @param {Number} input - an integer value to clamp.
+     * @return {Number} an integer from 0 to `categoryCount - 1`
+     * @private
+     */
+    _clampIndex(input) {
+      const { categoryCount } = this;
+      const maxIndex = categoryCount - 1;
+
+      if (input < 0) {
+        return 0;
+      } else if (input > maxIndex) {
+        return maxIndex;
+      } else {
+        return input;
+      }
+    }
+  },
+
+  computed: {
+    /**
+     * Returns the number of score categories.
+     * @return {Number}
+     */
+    categoryCount() {
+      return this.categoryLabels.length;
+    },
+
+    /**
+     * Scales the score, which ranges from 0 to 1 to a number between 0 and 5.
+     * @return {Number}
+     */
+    scaledScore() {
+      return this.score * this.categoryCount;
+    },
+
+    /**
+     * Returns the category the score falls into, as a string.
+     * @return {String} a string in `categoryLabels`
+     */
+    category() {
+      const { scaledScore, categoryLabels } = this;
+      const categoryIndex = this._clampIndex(Math.floor(scaledScore));
+      return categoryLabels[categoryIndex];
+    }
+  }
+};
+</script>

--- a/src/components/AnnotationSufficiency.vue
+++ b/src/components/AnnotationSufficiency.vue
@@ -84,7 +84,8 @@ export default {
      * @return {Number}
      */
     categoryCount() {
-      return this.categoryLabels.length;
+      const { categoryLabels } = this;
+      return categoryLabels.length;
     },
 
     /**
@@ -92,7 +93,8 @@ export default {
      * @return {Number}
      */
     scaledScore() {
-      return this.score * this.categoryCount;
+      const { score, categoryCount } = this;
+      return score * categoryCount;
     },
 
     /**

--- a/src/components/SearchPage.vue
+++ b/src/components/SearchPage.vue
@@ -27,10 +27,7 @@
 
       <!-- annotation sufficiency information -->
       <div class="grid-x grid-margin-x">
-        <!-- TODO: put this in a component -->
-        <div class="cell medium-8 large-6">
-          <p>Profile sufficiency: {{ qualityScore }}</p>
-        </div>
+        <AnnotationSufficiency class="cell medium-8 large-6" :score="qualityScore"/>
       </div>
 
       <!-- saved terms -->
@@ -55,12 +52,14 @@
 <script>
 import { mapState } from 'vuex';
 import SearchInput from './SearchInput';
+import AnnotationSufficiency from './AnnotationSufficiency';
 
 export default {
   name: 'SearchPage',
 
   components: {
-    SearchInput
+    SearchInput,
+    AnnotationSufficiency
   },
 
   methods: {

--- a/test/unit/specs/components/AnnotationSufficiency.spec.js
+++ b/test/unit/specs/components/AnnotationSufficiency.spec.js
@@ -1,0 +1,83 @@
+import { shallow } from '@vue/test-utils';
+
+import AnnotationSufficiency from '@/components/AnnotationSufficiency';
+import StarRating from 'vue-star-rating';
+
+describe('AnnotationSufficiency.vue', () => {
+  test('rendering', () => {
+    const wrapper = shallow(AnnotationSufficiency, {
+      propsData: {
+        score: 0.4
+      }
+    });
+
+    // Renders a span with the score category
+    const categorySpan = wrapper.find('span.score-category');
+    expect(categorySpan.exists()).toBe(true);
+    expect(categorySpan.text()).toEqual('Fair');
+
+    // Renders a component with the score
+    const scoreComponent = wrapper.find(StarRating);
+    expect(scoreComponent.exists()).toBe(true);
+
+    // Renders help text
+    const helpText = wrapper.find('p.score-help');
+    expect(helpText.exists()).toBe(true);
+    expect(helpText.find('ul').exists()).toBe(true);
+  });
+
+  test('clampIndex helper method', () => {
+    const wrapper = shallow(AnnotationSufficiency);
+
+    expect(wrapper.vm._clampIndex(-1)).toEqual(0);
+    expect(wrapper.vm._clampIndex(0)).toEqual(0);
+    expect(wrapper.vm._clampIndex(2)).toEqual(2);
+    expect(wrapper.vm._clampIndex(4)).toEqual(4);
+    expect(wrapper.vm._clampIndex(5)).toEqual(4);
+  });
+
+  describe('computed properties', () => {
+    test('categoryCount', () => {
+      const wrapper = shallow(AnnotationSufficiency);
+      expect(wrapper.vm.categoryCount).toEqual(wrapper.vm.categoryLabels.length);
+    });
+
+    test('scaledScore', () => {
+      const wrapper = shallow(AnnotationSufficiency, {
+        propsData: {
+          score: 0
+        }
+      });
+
+      expect(wrapper.vm.scaledScore).toEqual(0);
+
+      wrapper.setProps({ score: 0.2 });
+      expect(wrapper.vm.scaledScore).toEqual(1.0);
+    });
+
+    test('category', () => {
+      const wrapper = shallow(AnnotationSufficiency, {
+        propsData: {
+          score: 0
+        }
+      });
+
+      expect(wrapper.vm.category).toEqual('Very Poor');
+
+      wrapper.setProps({ score: 0.2 });
+      expect(wrapper.vm.category).toEqual('Poor');
+
+      wrapper.setProps({ score: 0.4 });
+      expect(wrapper.vm.category).toEqual('Fair');
+
+      wrapper.setProps({ score: 0.6 });
+      expect(wrapper.vm.category).toEqual('Good');
+
+      wrapper.setProps({ score: 0.8 });
+      expect(wrapper.vm.category).toEqual('Very Good');
+
+      wrapper.setProps({ score: 1.0 });
+      expect(wrapper.vm.category).toEqual('Very Good');
+    });
+  });
+});

--- a/test/unit/specs/components/SearchPage.spec.js
+++ b/test/unit/specs/components/SearchPage.spec.js
@@ -3,6 +3,8 @@ import { shallow, createLocalVue } from '@vue/test-utils';
 
 import SearchPage from '@/components/SearchPage';
 import SearchInput from '@/components/SearchInput';
+import AnnotationSufficiency from '@/components/AnnotationSufficiency';
+
 import exampleTerms from '../../example-terms';
 
 const localVue = createLocalVue();
@@ -32,6 +34,11 @@ describe('SearchPage.vue', () => {
     const wrapper = shallow(SearchPage, { store, localVue });
     expect(wrapper.find('form').exists()).toBe(true);
     expect(wrapper.find(SearchInput).exists()).toBe(true);
+  });
+
+  test('renders diagnostic quality feedback (annotation sufficiency)', () => {
+    const wrapper = shallow(SearchPage, { store, localVue });
+    expect(wrapper.find(AnnotationSufficiency).exists()).toBe(true);
   });
 
   test('renders a tag for each selected term', () => {


### PR DESCRIPTION
Add a component for displaying annotation sufficiency scoring information. See #33. I'm still working with Liz on text and styling, but the functionality is there.

How it looks:

<img width="593" alt="quality-score-wip" src="https://user-images.githubusercontent.com/2746306/41318613-c847b288-6e4d-11e8-8ee7-5f74d3d56b85.png">
