### PR TITLE
Export Document Improvements

### DIFF
--- a/src/utils/create-export-document.js
+++ b/src/utils/create-export-document.js
@@ -18,9 +18,41 @@ const colors = {
  *   terms
  */
 function createBaseDocument() {
+  const url = window.location.origin + window.location.pathname;
+
   return {
+    header: {
+      style: 'pageHeaderOrFooter',
+      columns: [
+        { text: `Phenotypr Body: ${url}`, link: url, style: 'link' },
+        { text: new Date().toLocaleDateString(), alignment: 'right' }
+      ]
+    },
+
+    footer: (currentPage, pageCount) => {
+      return {
+        text: `Page ${currentPage} of ${pageCount}`,
+        style: 'pageHeaderOrFooter',
+        alignment: 'center'
+      };
+    },
+
     content: [
-      { text: 'Your HPO Terms', style: 'heading' },
+      {
+        text: 'Your HPO Terms',
+        style: 'heading'
+      },
+      '\n',
+      {
+        text: [
+          'The table below shows the symptoms you selected using the ',
+          { text: 'Phenotypr Body tool', link: url, style: 'link' },
+          ' and the corresponding HPO terms. Knowing you or your child\'s HPO mapping can ',
+          'provide your healthcare provider access to quality, structured phenotyping data. ',
+          'Providing this information to your clinicians can assist in diagnosis (e.g., ',
+          'there may be something your medical team doesn\'t know about!).'
+        ]
+      },
       '\n',
       TABLE_PLACEHOLDER
     ],
@@ -29,6 +61,18 @@ function createBaseDocument() {
         fontSize: 16,
         bold: true,
         color: colors.heading
+      },
+      link: {
+        color: colors.heading,
+        decoration: 'underline'
+      },
+      pageHeaderOrFooter: {
+        fontSize: 9,
+        italic: true,
+        marginLeft: 40,
+        marginRight: 40,
+        marginTop: 10,
+        marginBottom: 10
       },
       tableHeaderCell: {
         bold: true,

--- a/src/utils/create-export-document.js
+++ b/src/utils/create-export-document.js
@@ -1,5 +1,3 @@
-const TABLE_PLACEHOLDER = 'TABLE_PLACEHOLDER';
-
 const colors = {
   white: '#ffffff',
   black: '#000000',
@@ -39,10 +37,9 @@ function createBaseDocument() {
 
     content: [
       {
-        text: 'Your HPO Terms',
+        text: 'Your HPO Terms\n\n',
         style: 'heading'
       },
-      '\n',
       {
         text: [
           'The table below shows the symptoms you selected using the ',
@@ -50,11 +47,9 @@ function createBaseDocument() {
           ' and the corresponding HPO terms. Knowing you or your child\'s HPO mapping can ',
           'provide your healthcare provider access to quality, structured phenotyping data. ',
           'Providing this information to your clinicians can assist in diagnosis (e.g., ',
-          'there may be something your medical team doesn\'t know about!).'
+          'there may be something your medical team doesn\'t know about!).\n\n'
         ]
-      },
-      '\n',
-      TABLE_PLACEHOLDER
+      }
     ],
     styles: {
       heading: {
@@ -135,9 +130,7 @@ export default function createExportDocument(terms) {
   }
 
   const doc = createBaseDocument();
-  const termTable = createTermTable(terms);
-
-  doc.content = doc.content.map(item => item === TABLE_PLACEHOLDER ? termTable : item);
+  doc.content.push(createTermTable(terms));
 
   return doc;
 }

--- a/test/unit/specs/utils/create-export-document.spec.js
+++ b/test/unit/specs/utils/create-export-document.spec.js
@@ -26,6 +26,11 @@ describe('createExportDocument utility', () => {
       expect(isExportDocument(doc)).toBe(true);
     });
 
+    test('contains a header and footer', () => {
+      expect(doc.header).toBeTruthy();
+      expect(doc.footer).toBeTruthy();
+    });
+
     test('contains a single table', () => {
       const [ tableNode, ...rest ] = doc.content.filter(tableFilter);
       expect(tableNode).toBeTruthy();


### PR DESCRIPTION
Add header and footer text and an introductory paragraph with a link to the application to the PDF export. Fixed #32.

Example PDF: [phenotypr-body-export.pdf](https://github.com/OCTRI/phenotypr-body/files/2099363/phenotypr-body-export.pdf)
