### PR TITLE
Handle Unknown Routes

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -58,6 +58,10 @@ export const routes = [
     path: termsOfUsePath,
     component: TermsOfUsePage,
     beforeEnter: skipWhenAlreadyAccepted
+  },
+  {
+    path: '*',
+    redirect: '/'
   }
 ];
 

--- a/test/unit/specs/router/router.spec.js
+++ b/test/unit/specs/router/router.spec.js
@@ -21,9 +21,15 @@ describe('router', () => {
   const termsRequiredRoute = { path: '/example', meta: { requireTermsOfUse: true } };
   const noMetaRoute = { path: '/example' };
 
+  test('there is a default route for unmatched paths', () => {
+    const defaultRoute = routes[routes.length - 1];
+    expect(defaultRoute.path).toEqual('*');
+    expect(defaultRoute.redirect).toEqual('/');
+  });
+
   describe('checkTermsAccepted() guard', () => {
     test('routes have metadata indicating if terms need to be accepted', () => {
-      const unprotected = [ termsRoute.path ];
+      const unprotected = [ termsRoute.path, '*' ];
       routes.forEach(route => {
         if (!unprotected.includes(route.path)) {
           expect(route.meta).toBeTruthy();


### PR DESCRIPTION
Handle unknown routes by adding a catch all route that redirects to the root route. Resolves #46.