### PR TITLE
Clean up tests from new routing

### DIFF
--- a/test/unit/specs/components/FeedbackPage.spec.js
+++ b/test/unit/specs/components/FeedbackPage.spec.js
@@ -76,19 +76,6 @@ describe('FeedbackPage.vue', () => {
     expect(forwardButton.attributes().disabled).toBeFalsy();
   });
 
-  test('clicking the back button transitions to the search route', () => {
-    const mocks = {
-      $router: {
-        push: jest.fn()
-      }
-    };
-
-    const wrapper = shallowMount(FeedbackPage, { store, localVue, mocks });
-
-    wrapper.find('input[name=backButton]').trigger('click');
-    expect(mocks.$router.push).toHaveBeenCalledWith('/search');
-  });
-
   test('clicking the forward button transitions to the results route', () => {
     const mocks = {
       $router: {

--- a/test/unit/specs/components/SearchPage.spec.js
+++ b/test/unit/specs/components/SearchPage.spec.js
@@ -95,19 +95,6 @@ describe('SearchPage.vue', () => {
       expect(actions.calculateQualityScore).toHaveBeenCalled();
     });
 
-    test('clicking the back button transitions to the body systems route', () => {
-      const mocks = {
-        $router: {
-          push: jest.fn()
-        }
-      };
-
-      const wrapper = shallowMount(SearchPage, { store, localVue, mocks });
-
-      wrapper.find('input[name=backButton]').trigger('click');
-      expect(mocks.$router.push).toHaveBeenCalledWith('/body-systems');
-    });
-
     test('clicking the submit button transitions to the results route', () => {
       const mocks = {
         $router: {


### PR DESCRIPTION
The new routing removed the back button from the workflow. Remove tests related to it.