### PR TITLE
Persistence Bug

### DIFF
--- a/src/services/data-logging-service.js
+++ b/src/services/data-logging-service.js
@@ -1,10 +1,60 @@
 /* eslint-disable camelcase */
 import { isValidTerm, isValidId } from '@/utils/term-utils';
+const hasSymptom = term => term.hasOwnProperty('symptom');
 
 /**
  * A service that performs HTTP requests to save the terms selected by the user.
  */
 export default {
+  /**
+   * Verify that the input looks like a session ID.
+   *
+   * @param {Any} sessionId
+   */
+  _validateSessionId(sessionId) {
+    const valid = Boolean(sessionId && typeof sessionId === 'string');
+    if (!valid) {
+      throw new Error('session_id: A string session ID is required');
+    }
+  },
+
+  /**
+   * Verify that input looks like an array of HPO terms with symptoms.
+   *
+   * @param {Any} terms
+   */
+  _validateTerms(terms) {
+    const valid = Array.isArray(terms) && terms.every(isValidTerm) &&
+      terms.every(hasSymptom);
+    if (!valid) {
+      throw new Error('selected_terms: An array of HPO terms is required');
+    }
+  },
+
+  /**
+   * Verify that input looks like an array of HPO IDs.
+   *
+   * @param {Any} systems
+   */
+  _validateSystems(systems) {
+    const valid = Array.isArray(systems) && systems.every(isValidId);
+    if (!valid) {
+      throw new Error('selected_systems: An array of HPO IDs is required');
+    }
+  },
+
+  /**
+   * Verify that input looks like a boolean flag.
+   *
+   * @param {Any} flag
+   */
+  _validateFoundAllFlag(flag) {
+    const valid = typeof flag === 'boolean';
+    if (!valid) {
+      throw new Error('found_all: Should be true or false');
+    }
+  },
+
   /**
    * Verify that required request inputs were received.
    *
@@ -12,22 +62,10 @@ export default {
    */
   _validateInput(data) {
     const { session_id, selected_terms, selected_systems, found_all } = data;
-
-    if (!session_id || typeof session_id !== 'string') {
-      throw new Error('session_id: A string session ID is required');
-    }
-
-    if (!Array.isArray(selected_terms) || !selected_terms.every(isValidTerm)) {
-      throw new Error('selected_terms: An array of HPO terms is required');
-    }
-
-    if (!Array.isArray(selected_systems) || !selected_systems.every(isValidId)) {
-      throw new Error('selected_systems: An array of HPO IDs is required');
-    }
-
-    if (found_all !== true && found_all !== false) {
-      throw new Error('found_all: Should be true or false');
-    }
+    this._validateSessionId(session_id);
+    this._validateTerms(selected_terms);
+    this._validateSystems(selected_systems);
+    this._validateFoundAllFlag(found_all);
   },
 
   /**

--- a/src/services/scoring-service.js
+++ b/src/services/scoring-service.js
@@ -16,7 +16,7 @@ export default {
    * @see example-score.js for an example response
    */
   score(terms) {
-    if (!terms || !Array.isArray(terms) || !terms.every(isValidTerm)) {
+    if (!Array.isArray(terms) || !terms.every(isValidTerm)) {
       throw new Error('An array of HPO terms is required');
     }
 

--- a/src/utils/term-utils.js
+++ b/src/utils/term-utils.js
@@ -22,8 +22,7 @@ export function isValidId(input) {
  * properties, and the ID is a string matching the pattern of an HPO term. False otherwise.
  */
 export function isValidTerm(input) {
-  return Boolean(input && input.id && input.label && input.symptomText &&
-      isValidId(input.id));
+  return Boolean(input && input.id && input.label && isValidId(input.id));
 }
 
 export default { isValidTerm, isValidId };

--- a/test/unit/example-session-data.js
+++ b/test/unit/example-session-data.js
@@ -2,9 +2,11 @@ import uuid from 'uuid/v4';
 import bodySystems from '@/store/systems';
 import exampleTerms from './example-terms';
 
+const mapTermShape = ({ id, label, symptomText }) => ({ id, label, symptom: symptomText });
+
 export default {
   session_id: uuid(),
   selected_systems: bodySystems.slice(0, 1).map(system => system.id),
-  selected_terms: exampleTerms.slice(0, 1),
+  selected_terms: exampleTerms.slice(0, 1).map(mapTermShape),
   found_all: true
 };

--- a/test/unit/specs/utils/term-utils.spec.js
+++ b/test/unit/specs/utils/term-utils.spec.js
@@ -22,14 +22,13 @@ describe('isValidTerm utility', () => {
     malformed.id = 42;
     expect(isValidTerm(malformed)).toBe(false);
 
+    // wrong ID format
+    malformed.id = 'hi';
+    expect(isValidTerm(malformed)).toBe(false);
+
     // missing label
     malformed = Object.assign({}, exampleTerms[0]);
     delete malformed.label;
-    expect(isValidTerm(malformed)).toBe(false);
-
-    // missing symptomText
-    malformed = Object.assign({}, exampleTerms[0]);
-    delete malformed.symptomText;
     expect(isValidTerm(malformed)).toBe(false);
   });
 


### PR DESCRIPTION
Term objects used by the persistence service are a slightly different shape from those used elsewhere, causing an exception when transitioning from feedback to the results page. Add code to account for the difference and refactor a bit.