### PR TITLE
Use solrconf defaults

### DIFF
--- a/src/services/search-service.js
+++ b/src/services/search-service.js
@@ -40,8 +40,6 @@ const defaultParams = {
   hl: 'on',
   'hl.snippets': '1000',
   'hl.simple.pre': '<em class="hilite">',
-  // Fields to query with boosting factors
-  qf: searchFields.map(field => `${field.name}^${field.boost}`).join(' '),
   // JSON output
   wt: 'json'
 };


### PR DESCRIPTION
Depends on building the latest from https://github.com/monarch-initiative/hpo-plain-index

Removes the qf param in favor of using defaults in the solrconfig.xml.  I'm leaving in the field - boost object in case we want to toggle clinical vs plain language autocompletion.