### PR TITLE
Pass entire query string into solr

### DIFF
--- a/src/services/search-service.js
+++ b/src/services/search-service.js
@@ -102,7 +102,9 @@ export default class SearchService {
       filterObject = { fq: this._buildFilter(filterTerms) };
     }
 
-    const params = Object.assign({}, defaultParams, { q: queryText }, filterObject);
+    const params = Object.assign(
+      {}, defaultParams, { q: `${queryText} + "${queryText}"` }, filterObject
+    );
     const queryString = qs.stringify(params, { addQueryPrefix: true });
 
     return `${this.searchUrl}${queryString}`;

--- a/test/unit/specs/services/search-service.spec.js
+++ b/test/unit/specs/services/search-service.spec.js
@@ -54,7 +54,9 @@ describe('search service', () => {
       expect(axios).toHaveBeenCalled();
       const searchUrl = axios.mock.calls[0][0];
       const queryString = searchUrl.split('?')[1];
-      expect(queryString).toMatch('q=plain%20language%20terms');
+      expect(queryString).toMatch(
+        'plain%20language%20terms%20%2B%20%22plain%20language%20terms%22'
+      );
     });
 
     test('it adds selected high level terms to the fq parameter', () => {


### PR DESCRIPTION
We find it useful when a user types more than one word to pass the entire string into the solr q param.  For example:
user types: foo bar
solr/select?q=foo bar "foo bar"

This is also necessary to leverage the keyword field.

Eg
https://solr.monarchinitiative.org/solr/hpo-pl/select/?q=low%20muscle+%20%22low%20muscle%22

vs.

https://solr.monarchinitiative.org/solr/hpo-pl/select/?q=low%20muscle