### PR TITLE
Add default field when adding filters

### DIFF
--- a/src/services/search-service.js
+++ b/src/services/search-service.js
@@ -96,9 +96,13 @@ export default class SearchService {
    * @private
    */
   _buildUrl(queryText, filterTerms) {
+    const defaultFilterTerms = [
+      'HP:0025142' // Constitutional symptom
+    ];
     let filterObject = {};
 
     if (Array.isArray(filterTerms) && filterTerms.length) {
+      filterTerms = filterTerms.concat(defaultFilterTerms);
       filterObject = { fq: this._buildFilter(filterTerms) };
     }
 

--- a/test/unit/specs/services/search-service.spec.js
+++ b/test/unit/specs/services/search-service.spec.js
@@ -63,7 +63,7 @@ describe('search service', () => {
       const expectedFilter = [
         'fq=phenotype_closure%3A%22HP%3A0000077%22%20OR%20',
         'phenotype_closure%3A%22HP%3A0003011%22%20OR%20',
-        'phenotype_closure%3A%22HP%3A0000951%22%20OR%20' +
+        'phenotype_closure%3A%22HP%3A0000951%22%20OR%20',
         'phenotype_closure%3A%22HP%3A0025142%22'
       ].join('');
 

--- a/test/unit/specs/services/search-service.spec.js
+++ b/test/unit/specs/services/search-service.spec.js
@@ -63,7 +63,8 @@ describe('search service', () => {
       const expectedFilter = [
         'fq=phenotype_closure%3A%22HP%3A0000077%22%20OR%20',
         'phenotype_closure%3A%22HP%3A0003011%22%20OR%20',
-        'phenotype_closure%3A%22HP%3A0000951%22'
+        'phenotype_closure%3A%22HP%3A0000951%22%20OR%20' +
+        'phenotype_closure%3A%22HP%3A0025142%22'
       ].join('');
 
       mockQueryResponse();


### PR DESCRIPTION
This PR adds the HPO term "constitutional symptom" as a default field in the search service when filters are applied.  Closes https://github.com/OCTRI/phenotypr-body/issues/83